### PR TITLE
Repaired the bug of the judgement of 'Error with duplicate read ID in different sources'

### DIFF
--- a/tama_collapse.py
+++ b/tama_collapse.py
@@ -6215,7 +6215,7 @@ if run_mode_flag == "original":
 
 
             ########################################################################################2020/12/14
-            if var_pos > len(fasta_dict[scaffold]) or var_pos < 0:
+            if var_pos >= len(fasta_dict[scaffold]) or var_pos < 0:
                 print("Read mapping off scaffold")
                 print(scaffold +" : "+ str(var_pos))
                 print(var_cov_trans_id_list)

--- a/tama_go/filter_transcript_models/tama_remove_polya_models_levels.py
+++ b/tama_go/filter_transcript_models/tama_remove_polya_models_levels.py
@@ -195,6 +195,7 @@ for line in read_file_contents:
             read_list = this_source_read_line.split(":")[1].split(",")
 
         for read_id in read_list:
+            read_id = "%s/%s" % (this_source_name, read_id)
             merge_trans_read_dict[merge_trans_id][read_id] = 1
             merge_source_read_dict[merge_trans_id][this_source_name][read_id] = 1
 
@@ -366,9 +367,10 @@ for gene_id in gene_list:
 
                 this_read_dict[this_read_id] = 1
 
-                if this_read_id in source_polya_read_dict[this_source_name]:
+                raw_read_id = this_read_id[this_read_id.find("/") + 1:]
+                if raw_read_id in source_polya_read_dict[this_source_name]:
 
-                    polya_percent = float(source_polya_read_dict[this_source_name][this_read_id][3])
+                    polya_percent = float(source_polya_read_dict[this_source_name][raw_read_id][3])
 
                     # print(polya_percent) ##################################
 
@@ -381,7 +383,7 @@ for gene_id in gene_list:
                         if trans_id not in this_trans_read_polya_support_dict:
                             this_trans_read_polya_support_dict[trans_id] = {}
 
-                        this_trans_read_polya_support_dict[trans_id][this_read_id] = source_polya_read_dict[this_source_name][this_read_id]
+                        this_trans_read_polya_support_dict[trans_id][this_read_id] = source_polya_read_dict[this_source_name][raw_read_id]
 
         #if trans_id == "G2.1":
         #    print("Pre checks")


### PR DESCRIPTION
An error 'Error with duplicate read ID in different sources' can be reported in tama_go/filter_transcript_models/tama_remove_polya_models_levels.py (line: 363)

Here, the read_id name of all transcripts in the same gene is required to be unique, but this is unreasonable. The read_id of reads that support the same gene but from different sources can be identical.